### PR TITLE
increased version to 0.1.10 - renamed keycloak envvar

### DIFF
--- a/charts/valtimo-backend/Chart.yaml
+++ b/charts/valtimo-backend/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.1.0
 description: A Helm chart for Kubernetes
 name: valtimo-backend
 type: application
-version: 0.1.9
+version: 0.1.10
 
 dependencies:
   - name: postgresql

--- a/charts/valtimo-backend/templates/configmap.yaml
+++ b/charts/valtimo-backend/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
   KEYCLOAK_AUTHSERVERURL: {{ .Values.settings.keycloak.authServerURL | quote }}
   KEYCLOAK_RESOURCE: {{ .Values.settings.keycloak.clientID | quote }}
   KEYCLOAK_REALM: {{ .Values.settings.keycloak.realm | quote }}
-  KEYCLOAK_PUBLIC_KEY: {{ .Values.settings.keycloak.publicKey | quote }}
+  VALTIMO_OAUTH_PUBLIC_KEY: {{ .Values.settings.keycloak.publicKey | quote }}
   VALTIMO_APP_HOSTNAME: {{ .Values.settings.valtimo.appHostname | quote }}
   VALTIMO_DATABASE: {{ .Values.settings.valtimo.databaseType | quote }}
   CAMUNDA_BPM_ADMINUSER_ID: {{ .Values.settings.camunda.adminUserID | quote }}

--- a/charts/valtimo-frontend/Chart.yaml
+++ b/charts/valtimo-frontend/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.1.0
 description: A Helm chart for Kubernetes
 name: valtimo-frontend
 type: application
-version: 0.1.5
+version: 0.1.10


### PR DESCRIPTION
changed envvar name from KEYCLOAK_PUBLIC_KEY to VALTIMO_OAUTH_PUBLIC_KEY See https://docs.valtimo.nl/using-valtimo/keycloak/configuring-keycloak#keycloak-token-authentication