### PR TITLE
Fix backend helm charts

### DIFF
--- a/charts/valtimo-backend/valtimo-backend/Chart.yaml
+++ b/charts/valtimo-backend/valtimo-backend/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 12.2.0
 description: A Helm chart for Kubernetes
 name: valtimo-backend
 type: application
-version: 3.0.17
+version: 3.1.0
 
 dependencies:
   - name: postgresql

--- a/charts/valtimo-backend/valtimo-backend/README.md
+++ b/charts/valtimo-backend/valtimo-backend/README.md
@@ -77,7 +77,6 @@ A Helm chart for Kubernetes
 | settings.camunda.adminUserID | string | `"admin"` | Default Camunda admin user |
 | settings.camunda.adminUserPassword | string | `""` | Default Camunda admin password |
 | settings.keycloak.authServerURL | string | `nil` | URL of Keycloak |
-| settings.keycloak.client | string | `nil` | Keycloak client - used to retrieve client roles |
 | settings.keycloak.clientID | string | `nil` | Client-ID to connect with Keycloak |
 | settings.keycloak.clientSecret | string | `""` | Client-Secret to connect with Keycloak |
 | settings.keycloak.publicKey | string | `nil` | Keycloak's Public Key used to verify signature of JWTs |

--- a/charts/valtimo-backend/valtimo-backend/README.md
+++ b/charts/valtimo-backend/valtimo-backend/README.md
@@ -77,6 +77,7 @@ A Helm chart for Kubernetes
 | settings.camunda.adminUserID | string | `"admin"` | Default Camunda admin user |
 | settings.camunda.adminUserPassword | string | `""` | Default Camunda admin password |
 | settings.keycloak.authServerURL | string | `nil` | URL of Keycloak |
+| settings.keycloak.client | string | `nil` | Keycloak client - used to retrieve client roles |
 | settings.keycloak.clientID | string | `nil` | Client-ID to connect with Keycloak |
 | settings.keycloak.clientSecret | string | `""` | Client-Secret to connect with Keycloak |
 | settings.keycloak.publicKey | string | `nil` | Keycloak's Public Key used to verify signature of JWTs |

--- a/charts/valtimo-backend/valtimo-backend/templates/configmap.yaml
+++ b/charts/valtimo-backend/valtimo-backend/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "valtimo-backend.fullname" . }}
+  name: {{ include "valtimo-backend.fullname" . }}
   labels:
     {{- include "valtimo-backend.labels" . | nindent 4 }}
 data:
@@ -9,11 +9,15 @@ data:
   SPRINGACTUATOR_USERNAME: {{ .Values.settings.spring.actuator.username | quote }}
   SPRING_DATASOURCE_URL: {{ .Values.settings.spring.datasource.url | quote }}
   SPRING_DATASOURCE_USERNAME: {{ .Values.settings.spring.datasource.username | quote }}
-  KEYCLOAK_AUTH_SERVER_URL: {{ .Values.settings.keycloak.authServerURL | quote }}
-  KEYCLOAK_RESOURCE: {{ .Values.settings.keycloak.clientID | quote }}
+  KEYCLOAK_AUTH_SERVER_URL: {{ required "You must set settings.keycloak.authServerURL" .Values.settings.keycloak.authServerURL | quote }}
+  KEYCLOAK_RESOURCE: {{ .Values.settings.keycloak.client | quote }}
   KEYCLOAK_REALM: {{ .Values.settings.keycloak.realm | quote }}
-  VALTIMO_KEYCLOAK_CLIENT: {{ .Values.settings.keycloak.client | quote }}
-  VALTIMO_OAUTH_PUBLIC_KEY: {{ .Values.settings.keycloak.publicKey | quote }}
+  VALTIMO_OAUTH_PUBLIC_KEY: {{ required "You must set settings.keycloak.publicKey" .Values.settings.keycloak.publicKey | quote }}
   VALTIMO_APP_HOSTNAME: {{ .Values.settings.valtimo.appHostname | quote }}
   VALTIMO_DATABASE: {{ .Values.settings.valtimo.databaseType | quote }}
   CAMUNDA_BPM_ADMINUSER_ID: {{ .Values.settings.camunda.adminUserID | quote }}
+  SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI: {{ printf "%s/auth/realms/%s/protocol/openid-connect/certs" .Values.settings.keycloak.authServerURL .Values.settings.keycloak.realm | quote }}
+  SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAKAPI_CLIENTID: {{ .Values.settings.keycloak.realmRoleId | quote }}
+  SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAKJWT_ISSUERURI: {{ printf "%s/realms/%s" .Values.settings.keycloak.authServerURL .Values.settings.keycloak.realm | quote }}
+  SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAKAPI_ISSUERURI: {{ printf "%s/realms/%s" .Values.settings.keycloak.authServerURL .Values.settings.keycloak.realm | quote  }}
+  SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAKJWT_CLIENTID: {{ .Values.settings.keycloak.clientID | quote }}

--- a/charts/valtimo-backend/valtimo-backend/templates/secret.yaml
+++ b/charts/valtimo-backend/valtimo-backend/templates/secret.yaml
@@ -12,4 +12,5 @@ data:
   KEYCLOAK_CREDENTIALS_SECRET: {{ .Values.settings.keycloak.clientSecret | toString | b64enc | quote }}
   VALTIMO_CONNECTORENCRYPTION_SECRET: {{ .Values.settings.valtimo.connectorEncryptionSecret | toString | b64enc | quote }}
   CAMUNDA_BPM_ADMINUSER_PASSWORD: {{ .Values.settings.camunda.adminUserPassword | toString | b64enc | quote }}
+  SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAKAPI_CLIENTSECRET: {{ .Values.settings.keycloak.clientSecret | toString | b64enc | quote }}
 {{- end }}

--- a/charts/valtimo-backend/valtimo-backend/values.yaml
+++ b/charts/valtimo-backend/valtimo-backend/values.yaml
@@ -231,7 +231,7 @@ settings:
       username: "admin"
 
       # -- Password to access the Spring actuator endpoint
-      # Or, if using existingSecret:: SPRINGACTUATOR_PASSWORD
+      # Or, if using existingSecret: SPRINGACTUATOR_PASSWORD
       password: ""
     datasource: 
       # -- URL for the database
@@ -240,7 +240,7 @@ settings:
       username: 
 
       # -- Password for the database
-      # Or, if using existingSecret:: SPRING_DATASOURCE_PASSWORD
+      # Or, if using existingSecret: SPRING_DATASOURCE_PASSWORD
       password: ""
     
   keycloak: 
@@ -255,7 +255,7 @@ settings:
     realmRoleId: valtimo-console
 
     # -- Client-Secret to connect with Keycloak
-    # Or, if using existingSecret:: KEYCLOAK_CREDENTIALS_SECRET and SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAKAPI_CLIENTSECRET (must set both)
+    # Or, if using existingSecret: KEYCLOAK_CREDENTIALS_SECRET and SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAKAPI_CLIENTSECRET (must set both)
     clientSecret: ""
 
     # -- Keycloak's Public Key used to verify signature of JWTs - Required
@@ -270,7 +270,7 @@ settings:
     serverPort: 8080
 
     # -- Encryption secret
-    # Or, if using existingSecret:: VALTIMO_CONNECTORENCRYPTION_SECRET
+    # Or, if using existingSecret: VALTIMO_CONNECTORENCRYPTION_SECRET
     connectorEncryptionSecret: ""
 
   camunda: 
@@ -278,7 +278,7 @@ settings:
     adminUserID: "admin"
 
     # -- Default Camunda admin password
-    # Or, if using existingSecret:: CAMUNDA_BPM_ADMINUSER_PASSWORD
+    # Or, if using existingSecret: CAMUNDA_BPM_ADMINUSER_PASSWORD
     adminUserPassword: ""
 
 ##########################################################################

--- a/charts/valtimo-backend/valtimo-backend/values.yaml
+++ b/charts/valtimo-backend/valtimo-backend/values.yaml
@@ -229,29 +229,37 @@ settings:
     actuator: 
       # -- Username to access the Spring actuator endpoint
       username: "admin"
+
       # -- Password to access the Spring actuator endpoint
+      # Or, if using existingSecret:: SPRINGACTUATOR_PASSWORD
       password: ""
     datasource: 
       # -- URL for the database
       url: 
       # -- Username for the database
       username: 
+
       # -- Password for the database
+      # Or, if using existingSecret:: SPRING_DATASOURCE_PASSWORD
       password: ""
     
   keycloak: 
-    # -- URL of Keycloak
+    # -- URL of Keycloak - Required
     authServerURL: 
-    # -- Keycloak realm
-    realm: 
+    # -- Required: Keycloak realm - Required
+    realm:
     # -- Client-ID to connect with Keycloak
-    clientID: 
+    clientID: valtimo-user-m2m-client
+    # -- Client-ID for using Valtimo with Keycloak realm roles
+    # More info: https://docs.valtimo.nl/running-valtimo/application-configuration/configuring-keycloak#client-roles
+    realmRoleId: valtimo-console
+
     # -- Client-Secret to connect with Keycloak
+    # Or, if using existingSecret:: KEYCLOAK_CREDENTIALS_SECRET and SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAKAPI_CLIENTSECRET (must set both)
     clientSecret: ""
-    # -- Keycloak's Public Key used to verify signature of JWTs
-    publicKey:
-    # -- Keycloak client - used to retrieve client roles
-    client:
+
+    # -- Keycloak's Public Key used to verify signature of JWTs - Required
+    publicKey: ""
 
   valtimo: 
     # -- Type of database to use (can by either 'postgres' or 'mysql')
@@ -260,13 +268,17 @@ settings:
     appHostName: 
     # -- The port on which Valtimo-backend is listening
     serverPort: 8080
+
     # -- Encryption secret
+    # Or, if using existingSecret:: VALTIMO_CONNECTORENCRYPTION_SECRET
     connectorEncryptionSecret: ""
 
   camunda: 
     # -- Default Camunda admin user
     adminUserID: "admin"
+
     # -- Default Camunda admin password
+    # Or, if using existingSecret:: CAMUNDA_BPM_ADMINUSER_PASSWORD
     adminUserPassword: ""
 
 ##########################################################################


### PR DESCRIPTION
- Add required env vars in configmap for valtimo 12
- Make some values required
- Infer URLs from `settings.keycloak.authServerURL`

Some changes are breaking, so this will be v3.1.0